### PR TITLE
Tweak: (`github-workflows`) - Include 'closed' event in `2-manage-runners.yml`

### DIFF
--- a/.github/workflows/2-manage-runners.yml
+++ b/.github/workflows/2-manage-runners.yml
@@ -5,7 +5,7 @@ name: Manage runners
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, closed]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### **User description**
The 'closed' event type is added to the list of triggers for the `2-manage-runners.yml` workflow. This will allow the workflow to be executed when a pull request is closed.


___

### **PR Type**
enhancement


___

### **Description**
- Added the 'closed' event type to the list of triggers for the `2-manage-runners.yml` workflow.
- This change allows the workflow to be executed when a pull request is closed.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>2-manage-runners.yml</strong><dd><code>Include 'closed' event in workflow triggers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/2-manage-runners.yml

- Added 'closed' event to the list of triggers for the workflow.



</details>
    

  </td>
  <td><a href="https://github.com/ZenFlux/zenflux/pull/44/files#diff-356a9507151146fd0551c973633602a2dca1a8f536e4796694c3c32113dae443">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

