### PR TITLE
Feature: (`zenflux-typescript-vm`) - Resolving of workspace packages, by manually add the paths

### DIFF
--- a/packages/zenflux-typescript-vm/README.md
+++ b/packages/zenflux-typescript-vm/README.md
@@ -53,6 +53,14 @@ vm.defineConfig( {
     workspacePath: path.resolve( currentDir, "../../../" ),
 
     /**
+     * Enable support for resolving workspace packages, by manually add the paths.
+     */
+    workspacePackagesPaths: [
+        path.resolve( currentDir, "../packages-A/" ),
+        path.resolve( currentDir, "../packages-B/" ),   
+    ],
+
+    /**
      * Determines whether to use ts-node compiler or not.
      */
     useTsNode: false,


### PR DESCRIPTION
### **PR Type**
documentation, enhancement


___

### **Description**
- Added documentation for the `workspacePackagesPaths` configuration in the `README.md` file.
- Described how to manually add paths for resolving workspace packages.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document support for resolving workspace packages manually</code></dd></summary>
<hr>
      
packages/zenflux-typescript-vm/README.md

<li>Added documentation for <code>workspacePackagesPaths</code> configuration.<br> <li> Described paths for resolving workspace packages manually.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ZenFlux/zenflux/pull/54/files#diff-17a31e824246a8d9f728a01526f93c29d9164b775f37c21b597b41aced4d1229">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

