### PR TITLE
Tweak: (`zenflux-cli`) - Update `@registry` in `readme.md`

### DIFF
--- a/packages/zenflux-cli/README.md
+++ b/packages/zenflux-cli/README.md
@@ -19,7 +19,7 @@ Via package manager, `bun install @zenflux/cli`
 
 ## 📦 Features
 
-The CLI provides several commands, each starting with the `@` symbol. 
+The CLI provides several commands, each starting with the `@` symbol.
 
 These commands are designed to help you manage and build your projects efficiently.
 
@@ -246,25 +246,32 @@ The tool supports publishing npm packages to a registry. It includes features fo
 ### Registry Operations
 
 The tool handles interactions with npm registries, creating a local npm registry for testing and development purposes
+
 - **CLI Commands**: `@registry`
   <br /><br />
-- **Default Behavior**:
-  - `@z-cli @registry @server`
-      - Starts a local npm registry and create custom npm (`.npmrc`) configuration file that connects to the local registry
-  - `@z-cli @registry @use`
-      - Uses the custom npm configuration file to connect to the local registry
-<br /><br />
+
 - **Sub Commands**:
   - **@server:**
-      - Description: Starts a local npm registry server
+      - Description: Starts a local npm registry server.
       - Usage: `@z-cli @registry @server`
-<br /><br />
+        <br /><br />
   - **@use:**
-      - Description: Use npm with custom configuration, which will be forwarded to the local npm server
+      - Description: Use npm with custom configuration, which will be forwarded to the local npm server.
+      - Arguments:
+          - `id`: Id of the npm registry server, can be obtained using: `@registry @list` command
+          - `command`: A npm command to execute against the registry
       - Examples:
-          - `@z-cli @registry @use npm <command>`
-          - `@z-cli @registry @use npm whoami`
-          - `@z-cli @registry @use npm install`
+          - `@z-cli @registry @use npm <id> <command>`
+          - `@z-cli @registry @use npm 4a1a whoami`
+          - `@z-cli @registry @use npm 4a1a install`
+  - **@list:**
+      - Description: List all online npm registry servers.
+      - Usage: `@z-cli @registry @list`
+  - **@clean:**
+      - Description: Delete current npm registry server and '.npmrc' token.
+      - Usage: `@z-cli @registry @clean`
+        <br /><br />
+
 <br /><br />
 ### Global arguments
 - **--zvm-verbose:** Log [tsnode-vm](https://github.com/ZenFlux/zenflux/tree/main/packages/zenflux-tsnode-vm) verbose, shows modules resolution


### PR DESCRIPTION
### **User description**
Updated the documentation for the `@registry` command by adding and detailing sub-commands like `@use`, `@list`, and `@clean`. This enhances clarity on how multiple registries are handled, allowing users to better manage npm commands execution against specified registries.


___

### **PR Type**
Documentation


___

### **Description**
- Updated the documentation for the `@registry` command in `README.md`.
- Added detailed descriptions and usage examples for the `@server`, `@use`, `@list`, and `@clean` sub-commands.
- Enhanced clarity on how to manage multiple npm registries using the CLI.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update `@registry` command documentation with sub-commands details</code></dd></summary>
<hr>

packages/zenflux-cli/README.md
<li>Added detailed descriptions for <code>@registry</code> sub-commands.<br> <li> Included usage examples and arguments for <code>@use</code> sub-command.<br> <li> Added new sub-commands <code>@list</code> and <code>@clean</code> with descriptions and usage.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ZenFlux/zenflux/pull/63/files#diff-250eb0657e2bcbc58573fa39146ae78a0504a065a16875da30c1729d16dcc36a">+20/-13</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

