### PR TITLE
New: (`zenflux-react-packages`) - Add lin job in workflow

### DIFF
--- a/.github/workflows/react-packages.yml
+++ b/.github/workflows/react-packages.yml
@@ -11,7 +11,7 @@ on:
         required: true
 
 jobs:
-  build-and-test:
+  lint:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 10
 
@@ -30,8 +30,67 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Restore ESLint cache
+        id: restore-eslint-cache
+        uses: actions/cache@v3
+        with:
+          path: .eslintcache
+          key: eslint-cache-${{ runner.os }}-${{ hashFiles('bun.lock', 'eslint.confg.js', '.eslintignore') }}
+          restore-keys: |
+            eslint-cache-${{ runner.os }}-
+
+      - name: Run ESLint
+        run: bun run @z-flux:react:eslint:ci
+
+      - name: Save ESLint cache
+        if: steps.restore-eslint-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v3
+        with:
+          path: .eslintcache
+          key: eslint-cache-${{ runner.os }}-${{ hashFiles('bun.lock', 'eslint.confg.js', '.eslintignore') }}
+
+  build:
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 10
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install
+
       - name: Build
         run: bun run @z-flux:react:build:ci
+
+  test:
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 10
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install
 
       - name: Run tests
         run: bun run @z-flux:react:test:ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .z
 
+.eslintcache
+
 dist
 node_modules
 log

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
         "@z-flux:react:build": "@z-cli @build --workspace react-* --dev",
         "@z-flux:react:dev": "@z-cli @watch --workspace react-* --dev",
         "@z-flux:react-reconciler-dev": "@z-cli @watch --workspace react-reconciler --dev",
-        "@z-flux:react:build:ci": "@z-cli @build --workspace \"react-*\" --haltOnDiagnosticError --no-diagnostic --no-declaration",
-        "@z-flux:react:test:ci": "@z-jest --selectedProjects react-test-renderer,react-cache,react-scheduler,internal-test-utils,react-reconciler"
+        "@z-flux:react:eslint:ci": "time ( bunx --bun eslint packages-react --cache --cache-strategy content )",
+        "@z-flux:react:build:ci": "time ( @z-cli @build --workspace \"react-*\" --haltOnDiagnosticError --no-diagnostic --no-declaration )",
+        "@z-flux:react:test:ci": "time ( @z-jest --selectedProjects react-test-renderer,react-cache,react-scheduler,internal-test-utils,react-reconciler )"
     },
-    "packageManager": "bun@1.1.27"
+    "packageManager": "bun@1.1.29"
 }


### PR DESCRIPTION
Integrated separate lint, build, and test jobs into the GitHub workflow for better CI/CD practices. Added `@z-flux:react:eslint:ci` npm script for running ESLint. Also updated `bun` package manager version to `1.1.29` in `package.json`.