### PR TITLE
Tweak: (`zenflux-react-packages`) - Reorder build and lint jobs in re…

### DIFF
--- a/.github/workflows/react-packages.yml
+++ b/.github/workflows/react-packages.yml
@@ -11,9 +11,32 @@ on:
         required: true
 
 jobs:
+  build:
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build
+        run: bun run @z-flux:react:build:ci
+
   lint:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 10
+    needs: build
 
     steps:
       - uses: actions/checkout@v4
@@ -48,29 +71,6 @@ jobs:
         with:
           path: .eslintcache
           key: eslint-cache-${{ runner.os }}-${{ hashFiles('bun.lock', 'eslint.confg.js', '.eslintignore') }}
-
-  build:
-    runs-on: ${{ inputs.runs-on }}
-    timeout-minutes: 10
-    needs: lint
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
-
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Build
-        run: bun run @z-flux:react:build:ci
 
   test:
     runs-on: ${{ inputs.runs-on }}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "@z-flux:react:dev": "@z-cli @watch --workspace react-* --dev",
         "@z-flux:react-reconciler-dev": "@z-cli @watch --workspace react-reconciler --dev",
         "@z-flux:react:eslint:ci": "time ( bunx --bun eslint packages-react --cache --cache-strategy content )",
-        "@z-flux:react:build:ci": "time ( @z-cli @build --workspace \"react-*\" --haltOnDiagnosticError --no-diagnostic --no-declaration )",
+        "@z-flux:react:build:ci": "time ( @z-cli @build --workspace \"react-*\" --haltOnDiagnosticError )",
         "@z-flux:react:test:ci": "time ( @z-jest --selectedProjects react-test-renderer,react-cache,react-scheduler,internal-test-utils,react-reconciler )"
     },
     "packageManager": "bun@1.1.29"


### PR DESCRIPTION
…act workflow

Reorganized the GitHub Actions workflow by moving the build job before the lint job. This ensures that linting occurs only after a successful build, optimizing the sequence of CI checks. Updated dependencies caching and build steps accordingly.